### PR TITLE
feat: Add organization-wide AGENTS.md with symlink pattern for AI agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,4 +143,4 @@ Individual repositories may override or extend these instructions with their own
 ## Task Master AI Instructions
 
 **Import Task Master's development workflow commands and guidelines when available:**
-@./.taskmaster/CLAUDE.md
+[See .taskmaster/CLAUDE.md for details.](./.taskmaster/CLAUDE.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in DDEV repositories.
+
+## Communication Style
+
+- Use direct, concise language without unnecessary adjectives or adverbs
+- Avoid flowery or marketing-style language ("tremendous", "dramatically", "revolutionary", "working perfectly", etc.)
+- Don't include flattery or excessive praise ("excellent!", "perfect!", "great job!")
+- State facts and findings directly without embellishment
+- Skip introductory phrases like "I'm excited to", "I'd be happy to", "Let me dive into"
+- Avoid concluding with summary statements unless specifically requested
+- When presenting options or analysis, lead with the core information, not commentary about it
+
+### AI Language Guidelines
+
+- Avoid words that reveal AI writing: "Comprehensive", "works perfectly", "You're absolutely right"
+- Don't say "perfect" in response to actions
+- Don't claim results are "ready for production use" without verification
+
+## DDEV Project Overview
+
+DDEV is an open-source tool for running local web development environments for PHP and Node.js. It uses Docker containers to provide consistent, isolated development environments with minimal configuration.
+
+For comprehensive developer documentation, see:
+
+- [Developer Documentation](https://docs.ddev.com/en/stable/developers/) - Complete developer guide
+- [Add-on Development](https://docs.ddev.com/en/stable/users/extend/creating-add-ons/) - DDEV add-on development guide
+
+## Common DDEV Development Patterns
+
+### Testing
+
+**For Core DDEV Projects:**
+- `go test -v ./pkg/[package]` - Test specific package
+- `make testpkg TESTARGS="-run TestName"` - Run subset of tests
+- `make staticrequired` - Run all required static analysis
+
+**For DDEV Add-ons:**
+- `bats tests` - Run add-on tests (primary testing strategy)
+- Manual testing: Create test project in `~/tmp/` and install add-on locally
+- Test with sample configurations in `tests/testdata/`
+
+### Whitespace and Formatting
+
+- **Never add trailing whitespace** - Blank lines must be completely empty (no spaces or tabs)
+- Match existing indentation style exactly (spaces vs tabs, indentation depth)
+- Preserve the file's existing line ending style
+- Run linting tools to catch whitespace issues before committing
+
+### Development Environment Setup
+
+- **Temporary files**: Use `~/tmp` for temporary directories and test projects
+- **Command execution**: For bash commands that don't start with a script or executable, wrap with `bash -c "..."`
+
+## Working with DDEV Repositories
+
+### Branch Naming
+
+Use descriptive branch names that include:
+
+- Date in YYYYMMDD format
+- Your GitHub username
+- Brief description of the work
+
+Format: `YYYYMMDD_<username>_<short_description>`
+
+Examples:
+
+- `20250925_rfay_move_to_ddev`
+- `20250925_username_fix_postgres`
+- `20250925_contributor_update_tests`
+
+**Branch Creation Strategy:**
+
+The recommended approach for creating branches is:
+
+```bash
+git fetch upstream && git checkout -b <branch_name> upstream/main --no-track
+```
+
+This method:
+
+- Fetches latest upstream changes
+- Creates branch directly from upstream/main
+- Doesn't require syncing local main branch
+- Uses --no-track to avoid tracking upstream/main
+
+### Pull Request Creation
+
+When creating pull requests for DDEV repositories, follow the PR template structure:
+
+**Required Sections:**
+
+- **The Issue:** Reference issue number with `#<issue>` and brief description
+- **How This PR Solves The Issue:** Technical explanation of the solution
+- **Manual Testing Instructions:** Step-by-step guide for testing changes
+- **Automated Testing Overview:** Description of tests or explanation why none needed
+- **Release/Deployment Notes:** Impact assessment and deployment considerations
+
+**Commit Message Format:**
+
+Follow Conventional Commits: `<type>[optional scope][optional !]: <description>[, fixes #<issue>]`
+
+Examples:
+
+- `fix: handle container networking timeout, fixes #1234`
+- `docs: clarify setup instructions`
+- `feat: add new service support`
+
+### Pre-Commit Workflow
+
+**For Core DDEV:**
+1. Run appropriate tests
+2. Run `make staticrequired` (REQUIRED)
+3. Fix any issues reported
+4. Stage and commit changes
+
+**For DDEV Add-ons:**
+1. Run `bats tests` or specific test files
+2. Test manually with local installation
+3. Fix any issues reported
+4. Stage and commit changes
+
+## Security & Configuration Tips
+
+- Do not commit secrets or API keys
+- Always use absolute paths when working with repository files
+- Focus on surgical, minimal changes that maintain compatibility
+- Handle credentials securely in any pull operations or integrations
+
+## Important Instruction Reminders
+
+Do what has been asked; nothing more, nothing less.
+NEVER create files unless they're absolutely necessary for achieving your goal.
+ALWAYS prefer editing an existing file to creating a new one.
+NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
+
+## Repository-Specific Instructions
+
+Individual repositories may override or extend these instructions with their own AGENTS.md file for project-specific guidance.
+
+## Task Master AI Instructions
+
+**Import Task Master's development workflow commands and guidelines when available:**
+@./.taskmaster/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,119 @@
 # .github
-Community Health templates for all of ddev
 
-Possibilities for this repo are described in [GitHub docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
+Community Health templates and AI agent instructions for all DDEV repositories.
+
+## Community Health Files
+
+GitHub automatically uses these files as defaults for any DDEV repository that doesn't have its own version:
+
+- `CONTRIBUTING.md` - Contribution guidelines
+- `CODE_OF_CONDUCT.md` - Code of conduct
+- `ISSUE_TEMPLATE/` - Issue templates
+- `PULL_REQUEST_TEMPLATE.md` - PR template
+- `SUPPORT.md` - Support information
+- `SECURITY.md` - Security policy
+
+For more information, see [GitHub's community health documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).
+
+## AI Agent Instructions
+
+This repository also provides organization-wide AI agent instructions through the **manual reference pattern**.
+
+### Files
+
+- **`AGENTS.md`** - Base AI agent instructions for all DDEV repositories
+- **`CLAUDE.md`** → `AGENTS.md` (symlink for Claude Code compatibility)
+- **`.github/copilot-instructions.md`** → `../AGENTS.md` (symlink for GitHub Copilot compatibility)
+
+### Strategy: Manual Reference Pattern
+
+Since AI agent instruction files (`AGENTS.md`, `CLAUDE.md`, `copilot-instructions.md`) are not GitHub community health files, they don't have automatic fallback behavior. Instead, we use a **manual reference pattern** where individual repositories explicitly reference the organization-wide instructions.
+
+**Why this approach:**
+- ✅ Works with any Git clone (no broken symlinks between repos)
+- ✅ Explicit and discoverable
+- ✅ Allows project-specific customization
+- ✅ Single source of truth for shared patterns
+- ✅ Compatible with all AI tools
+
+### Using in Your DDEV Repository
+
+#### For New Repositories
+
+1. **Create project-specific AGENTS.md:**
+
+```markdown
+# AGENTS.md
+
+This file provides guidance to AI agents when working with [PROJECT_NAME].
+
+## Project Overview
+
+[Brief description of your project]
+
+## Project-Specific Development
+
+[Add project-specific content like:]
+- Key commands and testing approaches
+- Architecture notes
+- Special configuration requirements
+- Development workflow specifics
+
+## General DDEV Development Patterns
+
+For standard DDEV organization patterns including communication style, branch naming, PR creation, security practices, and common development workflows, see the [organization-wide AGENTS.md](https://github.com/ddev/.github/blob/main/AGENTS.md).
+
+## Important Instruction Reminders
+
+Do what has been asked; nothing more, nothing less.
+NEVER create files unless they're absolutely necessary for achieving your goal.
+ALWAYS prefer editing an existing file to creating a new one.
+NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
+```
+
+2. **Create tool-specific symlinks:**
+
+```bash
+# For Claude Code compatibility
+ln -s AGENTS.md CLAUDE.md
+
+# For GitHub Copilot compatibility
+mkdir -p .github
+ln -s ../AGENTS.md .github/copilot-instructions.md
+```
+
+#### For Existing Repositories
+
+1. **Update existing AGENTS.md** to include reference to org-wide version
+2. **Remove duplicated content** that's now covered by the org-wide file
+3. **Keep project-specific content** (testing, architecture, special workflows)
+4. **Ensure tool symlinks exist** as shown above
+
+### Examples
+
+- **[ddev/ddev](https://github.com/ddev/ddev/blob/main/AGENTS.md)** - Core DDEV with Go development, Docker architecture
+- **[ddev/ddev-upsun](https://github.com/ddev/ddev-upsun/blob/main/AGENTS.md)** - Add-on with Bats testing, PHP actions, Upsun integration
+
+### Content Organization
+
+**Organization-wide AGENTS.md covers:**
+- Communication style and AI language guidelines
+- Branch naming conventions
+- Pull request creation workflows
+- Security and configuration practices
+- Common development environment setup
+- General troubleshooting patterns
+
+**Project-specific AGENTS.md should cover:**
+- Project architecture and key components
+- Specific testing strategies and commands
+- Build processes and validation workflows
+- Domain-specific development patterns
+- Integration with external services or platforms
+
+### Maintenance
+
+- **Update shared patterns** in this organization-wide AGENTS.md
+- **Individual repositories** automatically benefit through references
+- **Project-specific content** remains in individual repository files
+- **No complex automation** or synchronization required


### PR DESCRIPTION
## The Issue

We've been duplicating info in AGENTS.md etc, and we should be able to consolidate some of that at the org level

## How This PR Solves The Issue

- Create global AGENTS.md for DDEV organization repositories
- Include general communication style, development patterns, and workflows
- Add CLAUDE.md symlink in root for Claude Code accessibility
- Add .github/copilot-instructions.md symlink for GitHub Copilot
- Establish manual import pattern for project-specific overrides
- Focus on shared patterns: branching, PR templates, security practices
- Enable individual repos to reference and extend with project-specific content

🤖 Generated with [Claude Code](https://claude.ai/code)


## Release/Deployment Notes

* Now individual repos can have their own AGENTS.md that refers to this. Example: https://github.com/ddev/ddev-upsun/pull/8



